### PR TITLE
remove conversion of ans to int while submitting solution

### DIFF
--- a/support/support.py
+++ b/support/support.py
@@ -112,7 +112,7 @@ def submit_solution() -> int:
     args = parser.parse_args()
 
     year, day = get_year_day()
-    answer = int(sys.stdin.read())
+    answer = sys.stdin.read()
 
     print(f'answer: {answer}')
 


### PR DESCRIPTION
advent of code has string as answers too now , like on day 5 year 2022 , and even if the answer is an integer it still works ! so conversion to int is unnecessary